### PR TITLE
Set key as optional in sign message

### DIFF
--- a/src/contracts/message.ts
+++ b/src/contracts/message.ts
@@ -95,7 +95,7 @@ class Message {
             .cell()
     }
 
-    public sign (key: Uint8Array): Cell {
+    public sign (key?: Uint8Array): Cell {
         return this.parse(key)
     }
 


### PR DESCRIPTION
Not all messages require a signature, but `.sing()` in a particular implementation is necessary to complete the `Message X` object in the case of `MessageInternal` and `MessageExternalIn` messages. The key parameter now is optional. 

**TODO:** to clarify, perhaps `MessageInternal` should not require `.sing()` for the final cell assembly. 